### PR TITLE
Updated Game Menu Button Location

### DIFF
--- a/HardcoreDeath.lua
+++ b/HardcoreDeath.lua
@@ -645,7 +645,7 @@ HardcoreDeathLogGUI.logzones.text:SetPoint("TOPLEFT", 380, -38)
 
 
 HardcoreDeathLogFrame = CreateFrame("Button", "GameMenuButtonHardcoreDeathLogGUI", GameMenuFrame, "GameMenuButtonTemplate")
-HardcoreDeathLogFrame:SetPoint("TOP", GameMenuButtonMacros, "BOTTOM", 0, -1)
+HardcoreDeathLogFrame:SetPoint("TOP", GameMenuButtonMacros, "BOTTOM", 0, -110)
 HardcoreDeathLogFrame:SetText("Hardcore Death Log")
 HardcoreDeathLogFrame:SetScript("OnClick", function()
 	HideUIPanel(GameMenuFrame)


### PR DESCRIPTION
Updated location of button in game menu. It would normally sit on top of MoveAnything so I expanded the game menu in pfUI and changed the location of the button for Hardcore Death Log

![image](https://github.com/Lexiebean/HardcoreDeath/assets/115322320/2b2bcae9-2385-476e-8823-194df6adac89)
